### PR TITLE
local models support with openai api local wrappers

### DIFF
--- a/SibyllaSandbox/Program.cs
+++ b/SibyllaSandbox/Program.cs
@@ -27,7 +27,8 @@ builder.Services.AddSingleton<SibyllaManager>(new SibyllaManager(new Oraculum.Co
     OpenAIOrgId = _configuration["OpenAI:OrgId"],
     AzureOpenAIApiKey = _configuration["Azure:ApiKey"],
     AzureResourceName = _configuration["Azure:ResourceName"],
-    AzureDeploymentId = _configuration["Azure:DeploymentId"]
+    AzureDeploymentId = _configuration["Azure:DeploymentId"],
+    LocalProvider = _configuration["LocalProvider"]
 }, Path.Combine(_env.ContentRootPath, "SibyllaeConf")));
 
 builder.Services.AddServerSentEvents();

--- a/src/Oraculum/Oraculum.cs
+++ b/src/Oraculum/Oraculum.cs
@@ -27,7 +27,15 @@ public class Configuration
 
     internal OpenAIService CreateService()
     {
-        if (Provider == ProviderType.OpenAi)
+        if (LocalProvider != null)
+            return new OpenAIService(new OpenAiOptions()
+            {
+                ProviderType = ProviderType.OpenAi,
+                ApiKey = OpenAIApiKey!,
+                Organization = OpenAIOrgId,
+                BaseDomain = LocalProvider
+            });
+        else if (Provider == ProviderType.OpenAi)
             return new OpenAIService(new OpenAiOptions()
             {
                 ProviderType = ProviderType.OpenAi,
@@ -61,6 +69,7 @@ public class Configuration
     public string? WeaviateEndpoint { get; set; }
     public string? WeaviateApiKey { get; set; }
     public OpenAI.ProviderType Provider { get; set; } = ProviderType.OpenAi;
+    public string? LocalProvider { get; set; }
     public string? OpenAIApiKey { get; set; }
     public string? OpenAIOrgId { get; set; }
     public string? AzureDeploymentId { get; set; }

--- a/src/Oraculum/Sibylla.cs
+++ b/src/Oraculum/Sibylla.cs
@@ -36,7 +36,8 @@ namespace Oraculum
                 {
                     FactTypeFilter = FactFilter,
                     CategoryFilter = CategoryFilter,
-                    TagsFilter = TagFilter
+                    TagsFilter = TagFilter,
+                    Limit = Limit
                 };
             }
         }
@@ -51,6 +52,7 @@ namespace Oraculum
         public float? FrequencyPenalty { get; set; } = 0.0f;
         public float? PresencePenalty { get; set; } = 0.0f;
         public string[]? FactFilter { get; set; } = null;
+        public int? Limit { get; set; } = 5;
         public string[]? CategoryFilter { get; set; } = null;
         public string[]? TagFilter { get; set; } = null;
         public int FactMemoryTTL { get; set; } = 4; // 4 turns implies a maximum of 11 facts in memory


### PR DESCRIPTION
Added support local OpenAI api endpoints, LocalProvider able to be defined in configuration with the url where the model is hosted with a local OpenAI compatible server. Added Limit in configuration to set the number of facts retrieved by the vector store.