### PR TITLE
Fix PowerShell cmdlet path handling

### DIFF
--- a/cli/OraculumCLI/BackupFactsDB.cs
+++ b/cli/OraculumCLI/BackupFactsDB.cs
@@ -20,7 +20,8 @@ namespace OraculumCLI
         {
             base.ProcessRecord();
             var progress = new ProgressRecord(1, "restoring", "Number of facts restored");
-            var j = Connection.BackupFacts(FileName!, (num, total) => {
+            var path = SessionState.Path.GetUnresolvedProviderPathFromPSPath(FileName!);
+            var j = Connection.BackupFacts(path, (num, total) => {
                 progress.PercentComplete = (int)(num / (double)total);
                 progress.StatusDescription = $"Read {num} of {total} facts";
                 return 0;

--- a/cli/OraculumCLI/ConnectOraculum.cs
+++ b/cli/OraculumCLI/ConnectOraculum.cs
@@ -47,7 +47,8 @@ namespace OraculumCLI
         {
             if (ConfigFile != null)
             {
-                var json = System.IO.File.ReadAllText(ConfigFile);
+                var path = SessionState.Path.GetUnresolvedProviderPathFromPSPath(ConfigFile);
+                var json = System.IO.File.ReadAllText(path);
                 Config = OraculumConfiguration.FromJson(json)!;
             } else if (Config == null)
             {

--- a/cli/OraculumCLI/NewSibyllaConf.cs
+++ b/cli/OraculumCLI/NewSibyllaConf.cs
@@ -50,7 +50,8 @@ namespace OraculumCLI
             };
             if (File != null)
             {
-                System.IO.File.WriteAllText(File, JsonSerializer.Serialize(c));
+                var path = SessionState.Path.GetUnresolvedProviderPathFromPSPath(File);
+                System.IO.File.WriteAllText(path, JsonSerializer.Serialize(c));
             }
             WriteObject(c);
         }

--- a/cli/OraculumCLI/NewSibyllaSession.cs
+++ b/cli/OraculumCLI/NewSibyllaSession.cs
@@ -25,7 +25,8 @@ namespace OraculumCLI
             base.ProcessRecord();
             if (ConfigFile != null)
             {
-                var json = System.IO.File.ReadAllText(ConfigFile);
+                var path = SessionState.Path.GetUnresolvedProviderPathFromPSPath(ConfigFile);
+                var json = System.IO.File.ReadAllText(path);
                 Config = System.Text.Json.JsonSerializer.Deserialize<SibyllaConf>(json);
             } else if (Config == null)
             {

--- a/cli/OraculumCLI/RestoreFactsDB.cs
+++ b/cli/OraculumCLI/RestoreFactsDB.cs
@@ -29,7 +29,8 @@ namespace OraculumCLI
             }
 
             var progress = new ProgressRecord(otp, "restoring", "Number of facts restored");
-            var j = Connection.RestoreFacts(FileName!, (num, total) => {
+            var path = SessionState.Path.GetUnresolvedProviderPathFromPSPath(FileName!);
+            var j = Connection.RestoreFacts(path, (num, total) => {
                 progress.PercentComplete = (int)(num / (double)total);
                 progress.StatusDescription = $"Written {num} of {total} facts";
                 return 0;


### PR DESCRIPTION
## Summary
- fix ConfigFile handling in `Connect-Oraculum`
- respect current directory in `New-SibyllaSession`
- fix `New-SibyllaConf` output path
- allow backup/restore cmdlets to honour current directory

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*